### PR TITLE
Added -ForcePrompt to Get-GraphOauthAuthorizationCode.ps1.

### DIFF
--- a/docs/functions/Get-GraphOauthAuthorizationCode.md
+++ b/docs/functions/Get-GraphOauthAuthorizationCode.md
@@ -58,7 +58,6 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml


### PR DESCRIPTION
Use this to ignore cached logins and consents.  This is especially helpful when managing multiple tenants.